### PR TITLE
space removed

### DIFF
--- a/opt/minecraft
+++ b/opt/minecraft
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-public_ip= `wget http://ipecho.net/plain -O - -q ; echo`
+public_ip=`wget http://ipecho.net/plain -O - -q ; echo`
 mc_port=25565
 port=${1:-${PORT:-8080}}
 


### PR DESCRIPTION
Extra space after public_ip= is causing bash to treat the ip address as a commend to execute rather than a string to be assigned. Just moved the space as a fix.